### PR TITLE
[FEAT] 위치허용시 나의 위치, 거부시 영등포캠퍼스가 맵뷰의 중심이 되도록

### DIFF
--- a/TravelTalkProject/Enumeration.swift
+++ b/TravelTalkProject/Enumeration.swift
@@ -18,15 +18,15 @@ enum LabelStyle {
     func labelSetting(_ label: UILabel) -> UILabel {
         switch self {
         case .nickname:
-            return label.boldStyleLable(fontSize: 15, numberOfLines: 1)
+            return label.boldStyleLabel(fontSize: 15, numberOfLines: 1)
         case .recentMessage:
-            return label.boldStyleLable(textColor: .gray, fontSize: 14, numberOfLines: 1)
+            return label.boldStyleLabel(textColor: .gray, fontSize: 14, numberOfLines: 1)
         case .chatRoomMessage:
-            return label.boldStyleLable(fontSize: 14, numberOfLines: 0)
+            return label.boldStyleLabel(fontSize: 14, numberOfLines: 0)
         case .chatRoomNickname:
-            return label.boldStyleLable(fontSize: 14)
+            return label.boldStyleLabel(fontSize: 14)
         case .date:
-            return label.boldStyleLable(textColor: .gray, fontSize: 13, numberOfLines: 1)
+            return label.boldStyleLabel(textColor: .gray, fontSize: 13, numberOfLines: 1)
         }
     }
 }

--- a/TravelTalkProject/Extension/UILabel+Extension.swift
+++ b/TravelTalkProject/Extension/UILabel+Extension.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension UILabel {
-    func boldStyleLable(textColor: UIColor = .label, alignment: NSTextAlignment = .left, fontSize: CGFloat = 17, numberOfLines nol: Int = 1) -> UILabel {
+    func boldStyleLabel(textColor: UIColor = .label, alignment: NSTextAlignment = .left, fontSize: CGFloat = 17, numberOfLines nol: Int = 1) -> UILabel {
         self.textColor = textColor
         self.textAlignment = alignment
         self.font = .boldSystemFont(ofSize: fontSize)

--- a/TravelTalkProject/Info.plist
+++ b/TravelTalkProject/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>주변 영화관 탐색을 위해 현재 사용자의 위치 허용 권한이 필요합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/TravelTalkProject/TheaterMap/TheaterViewController.swift
+++ b/TravelTalkProject/TheaterMap/TheaterViewController.swift
@@ -19,39 +19,61 @@ class TheaterViewController: UIViewController {
     var pinList: [MKPointAnnotation] = []
 //    var annotation = MKPointAnnotation()
 
+    /// 제일 처음에 디폴트로 뜨는 장소(서울대입구역)
+    let defaultCoordinate: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 37.4824761978647, longitude: 126.9521680487202)
+    var coordinateMeters: CLLocationDistance = 15000
+    
+    /// 위치 허용하지 않았을 때 디폴트로 뜨는 장소 - 영등포 캠퍼스
+    let ydpCoordinate = CLLocationCoordinate2D(latitude: 37.51740601118354, longitude: 126.88669183880141)
+    
+    // annotationType이 AlertAction에서 선택될 때마다 알아서 핀을 다시 꼽는다.ㅎㅎ
     var annotationType: LocationType = .전체보기 {
         didSet {
-            mapView.removeAnnotations(pinList)
+            mapView.removeAnnotations(pinList) // 맵뷰에서 핀들 삭제
             pinList = [] // 다시 초기화
+            setMapCenter(center: defaultCoordinate, coordinateMeters: 15000)
             setAnnotation()
         }
     }
     
+    let locationManager = CLLocationManager() // class, 중앙집권적 관리
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        locationManager.delegate = self // 프로토콜 사용
+        
         configureView()
-        setAnnotation()
+        setMapCenter(center: defaultCoordinate, coordinateMeters: coordinateMeters) // 중심잡기
+        setAnnotation() // 핀 꼽기
         
 
     }
     func configureView() {
 
+        // rightBarButtonItems(s들어감)으로 하면 취대 두 개 넣을 수 있다
         let button = UIBarButtonItem(title: "Filter", image: nil, target: self, action: #selector(presentAlert))
         navigationItem.rightBarButtonItem = button
+        
+        // 위치 버튼
+        let myLocationButton = UIBarButtonItem(image: UIImage(systemName: "location.fill"), style: .plain, target: self, action: #selector(checkDeviceLocationAuthorization))
+        navigationItem.leftBarButtonItem = myLocationButton
         
     }
     
     /// 지도와 핀 다시 그리는 로직 함수
-    func setAnnotation() {
+    func setMapCenter(center: CLLocationCoordinate2D, coordinateMeters: CLLocationDistance) {
         
         // 서울대입구역 중심으로 핀이 다 나오도록
-        let coordinate = CLLocationCoordinate2D(latitude: 37.4824761978647, longitude: 126.9521680487202)
-        let region = MKCoordinateRegion(center: coordinate, latitudinalMeters: 15000, longitudinalMeters: 15000)
+        let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
+        let region = MKCoordinateRegion(center: coordinate, latitudinalMeters: coordinateMeters, longitudinalMeters: coordinateMeters)
         
         mapView.setRegion(region, animated: true)
         
-        print(annotationType.rawValue)
+    }
+    
+    /// 핀꼽는 함수
+    func setAnnotation() {
         if annotationType == .전체보기 {
             annotationList = originalAnnotations
         } else {
@@ -63,7 +85,7 @@ class TheaterViewController: UIViewController {
             print("didi")
             let coordinate = CLLocationCoordinate2D(latitude: item.latitude, longitude: item.longitude)
             
-            // 핀 여러개 꽂고 싶으면 여기에 선언해줘야한다. -> ?왜지...ㅎ
+            // 핀 여러개 꽂고 싶으면 여기에 선언해줘야한다. -> 인스턴스마다 각자로 등록되어있어야 한다.그래서 재활용하면 안됨.
             let annotation = MKPointAnnotation()
             annotation.coordinate = coordinate
             annotation.title = item.location
@@ -72,7 +94,98 @@ class TheaterViewController: UIViewController {
             mapView.addAnnotation(annotation)
         
         }
-  
+    }
+    
+}
+
+// 위치 권한관련 메서드
+extension TheaterViewController {
+    /// iOS 시스템의 권한 확인
+    @objc func checkDeviceLocationAuthorization() {
+        DispatchQueue.global().async {
+            if CLLocationManager.locationServicesEnabled() {
+                let authorizationStatus: CLAuthorizationStatus // enum인데 어떻게 let으로 해도 밴경가능? & 초기화 안해도 되는 이유??
+                
+                if #available(iOS 14.0, *) {
+                    authorizationStatus = self.locationManager.authorizationStatus
+                } else {
+                    authorizationStatus = CLLocationManager.authorizationStatus()
+                }
+                
+                DispatchQueue.main.async {
+                    self.checkCurrentLocationAuthorization(status: authorizationStatus)
+                }
+            }
+        }
+    }
+    
+    func checkCurrentLocationAuthorization(status: CLAuthorizationStatus) {
+        switch status {
+        case .notDetermined:
+            print("notDetermined")
+            locationManager.desiredAccuracy = kCLLocationAccuracyReduced
+            locationManager.requestWhenInUseAuthorization() // info랑 맞추기
+
+        case .denied: // 권한을 거부한 경우 영등포 캠퍼스가 맵뷰의 중심이 되도록
+            print("denied")
+            // 일단 영등포 캠퍼스(디폴트 장소) 띄우기
+            setMapCenter(center: ydpCoordinate, coordinateMeters: 100)
+            
+            showLocationSettingAlert() // 여기서 거절하면 그냥 끝, 허용하면? 다시 상태체크
+            
+        case .authorizedAlways:
+            print("authorizedAlways")
+            locationManager.startUpdatingLocation() //didupdateLocation함수 실행
+
+        case .authorizedWhenInUse:
+            print("authorizedWhenInUse")
+            locationManager.startUpdatingLocation() //didupdateLocation함수 실행
+
+        default: // 설정으로 허용하러 감 -> 허용해줌 - 들어오면 다시 상태체크해서 허용상태로 바로 가는건가?(한 번 허용해서 앱설정은 허용이 됐는데 다므에 들어갈떄 notdetermined라고 하면 알아서 설정앱에 권한switch도 풀리는건가?
+            print("Error")
+        }
+    }
+    
+    // 권한 거부 했을 때 설정으로 유도하는 alert
+    func showLocationSettingAlert() {
+        let alert = UIAlertController(title: "위치 정보 이용", message: "위치 서비스를 사용할 수 없습니다.", preferredStyle: .alert)
+        
+        let goSetting = UIAlertAction(title: "설정으로 이동", style: .default) { _ in
+            if let settingURL = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(settingURL)
+            } else {
+                print("설정 클릭 실패!")
+            }
+        }
+        
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(goSetting)
+        alert.addAction(cancel)
+        
+        present(alert, animated: true)
+    }
+}
+
+extension TheaterViewController: CLLocationManagerDelegate {
+    // 위치 허용 해준 경우
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        if let coordinate = locations.last?.coordinate {
+            // 사용자의 위치를 맵유의 중심으로
+            setMapCenter(center: coordinate, coordinateMeters: 100)
+
+        }
+    }
+    
+    // 위치 허용을 하지 않은 경우
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        // 중심을 영등포 캠퍼스로
+        setMapCenter(center: ydpCoordinate, coordinateMeters: 100)
+    }
+    
+    // 권한이 변경되었을 때
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        checkDeviceLocationAuthorization()
     }
 }
 


### PR DESCRIPTION
## 🚀관련 이슈
- close #8 

## 💎작업 내용
- setAnnotation 을 setCenter와 setAnnotation로 분리
- 위치 권한 확인 코드 추가
- 위치 허용시 나의 위치가 중심
- 거부시 영등포캠퍼스가 맵뷰 중심

## 📸 스크린샷
<img  width="30%" src="https://github.com/nhyeonjeong/TravelTalkProject/assets/102401977/8e1ea508-86a5-4f2c-b799-1850e2ce34b4"/>
<img  width="30%" src="https://github.com/nhyeonjeong/TravelTalkProject/assets/102401977/d6323622-d1ee-4b04-bd86-501e95303c6b"/>

## ⭐️참고 사항
- 나의 위치나 영등포 캠퍼스가 중심이 될 때 핀 꼽기 이후 리팩토링~
